### PR TITLE
faster recallculate, faster recent unknown morphes, added ability to …

### DIFF
--- a/ankimorphs/ankimorphs_db.py
+++ b/ankimorphs/ankimorphs_db.py
@@ -180,8 +180,8 @@ class AnkiMorphsDB:
 
         return card_morphs
 
-    def update_seen_morphs(self) -> None:
-        cards_studied_today: Sequence[int] = get_cards_seen_today()
+    def update_seen_unknown_morphs(self) -> None:
+        cards_studied_today: Sequence[int] = get_new_cards_seen_today()
 
         where_query_string = "WHERE" + "".join(
             [f" card_id = {card_id} OR" for card_id in cards_studied_today]
@@ -302,15 +302,14 @@ class AnkiMorphsDB:
             am_db.con.execute("DROP TABLE IF EXISTS Seen_Morphs;")
 
 
-def get_cards_seen_today() -> Sequence[int]:
+
+def get_new_cards_seen_today() -> Sequence[int]:
     assert mw is not None
 
     am_config = AnkiMorphsConfig()
     known_tag = am_config.tag_known
 
-    studied_today_search_string = mw.col.build_search_string(
-        SearchNode(rated=SearchNode.Rated(days=1, rating=SearchNode.RATING_ANY))
-    )
+    note_type_search_string = build_note_type_search_string()
 
     known_and_skipped_search_string = mw.col.build_search_string(
         SearchNode(card_state=SearchNode.CARD_STATE_BURIED),
@@ -318,8 +317,20 @@ def get_cards_seen_today() -> Sequence[int]:
     )
 
     total_search_string = (
-        studied_today_search_string + " OR " + known_and_skipped_search_string
+ "introduced:1 "+ note_type_search_string+ " "   + " OR (" + known_and_skipped_search_string + ")"
     )
 
     known_and_skipped_cards: Sequence[int] = mw.col.find_cards(total_search_string)
     return known_and_skipped_cards
+
+def build_note_type_search_string() -> str:
+    am_config = AnkiMorphsConfig()
+    i = 0
+    string = "("
+    for _filter in am_config.filters:
+        if i != 0:
+            string += " OR "
+        string += f'"note:{_filter.note_type}"'
+        i += 1
+    string += ")"
+    return string

--- a/ankimorphs/morph_utils.py
+++ b/ankimorphs/morph_utils.py
@@ -1,4 +1,8 @@
+import functools
+import os
 import re
+
+from aqt import mw
 
 from .config import AnkiMorphsConfig
 from .morpheme import Morpheme
@@ -14,6 +18,8 @@ def get_morphemes(
 ) -> list[Morpheme]:
     expression = _get_parsed_expression(expression, am_config)
     morphs = morphemizer.get_morphemes_from_expr(expression)
+    names_set = create_hash_set_out_of_names()
+    morphs = list(filter(lambda x: (x.inflected not in names_set) ,morphs))
     return morphs
 
 
@@ -35,3 +41,17 @@ def _get_parsed_expression(expression: str, am_config: AnkiMorphsConfig) -> str:
         expression = re.sub('["«»]', " ", expression)
 
     return expression
+
+@functools.cache
+def create_hash_set_out_of_names() -> set[str]:
+    profile_path = ""
+    if mw is not None:
+        profile_path = mw.pm.profileFolder()
+    else:
+        return set()
+    path: str = os.path.join(profile_path, "names.txt")
+    with open(path) as names_file:
+        lines_lower_case = map(lambda x: x.lower(),names_file.read().splitlines())
+        hashset = set(lines_lower_case)
+        return hashset
+    return set()

--- a/ankimorphs/reviewing_utils.py
+++ b/ankimorphs/reviewing_utils.py
@@ -71,7 +71,7 @@ def am_next_card(  # pylint:disable=too-many-branches,too-many-statements
     am_config = AnkiMorphsConfig()
     skipped_cards = SkippedCards(am_config)
     am_db = AnkiMorphsDB()
-    am_db.update_seen_morphs()
+    am_db.update_seen_unknown_morphs()
 
     while True:
         # If a break occurs in this loop it means 'show the card'


### PR DESCRIPTION
I made recalculate faster by using add_notes and add_cards instead of sql query, now it's able to recalculate 40k cards in under 2 minutes. I made already seen be much faster that  anki no longer freezes, the way I fixed it is that it no longer checks every card for unknown morphs only cards that the user has specified to use with morphman, also now it only looks for unknown morphs in cards that have been reviewed recently because if a card has already has non recently been reviewed it can't have recent unknown morphs. Also a list of proper nouns in their profile folder can add names.txt