### PR TITLE
Add dropdown to find a highlighted word in am-morphs when studying

### DIFF
--- a/ankimorphs/__init__.py
+++ b/ankimorphs/__init__.py
@@ -1,4 +1,4 @@
-################################################################
+###############################################################
 #                          IMPORTS
 ################################################################
 # We have to use implicit imports from the 'ankimorphs'-module
@@ -79,6 +79,7 @@ def main() -> None:
     gui_hooks.sync_will_start.append(recalc_on_sync)
 
     gui_hooks.webview_will_show_context_menu.append(add_name_action)
+    gui_hooks.webview_will_show_context_menu.append(browse_am_unknowns_action)
 
     gui_hooks.overview_did_refresh.append(update_seen_morphs)
 
@@ -469,6 +470,18 @@ def add_name_action(web_view: AnkiWebView, menu: QMenu) -> None:
     action.triggered.connect(lambda: name_file_utils.add_name_to_file(selected_text))
     action.triggered.connect(AnkiMorphsDB.insert_names_to_seen_morphs)
     action.triggered.connect(mw.reviewer.bury_current_card)
+    menu.addAction(action)
+
+
+def browse_am_unknowns_action(web_view: AnkiWebView, menu: QMenu) -> None:
+    assert mw is not None
+    selected_text = web_view.selectedText()
+    if selected_text == "":
+        return
+    action = QAction(f"Browse in {ankimorphs_globals.EXTRA_FIELD_UNKNOWNS}", menu)
+    action.triggered.connect(
+        lambda: browser_utils.browse_highlighted_morph(selected_text)
+    )
     menu.addAction(action)
 
 

--- a/ankimorphs/browser_utils.py
+++ b/ankimorphs/browser_utils.py
@@ -15,7 +15,7 @@ from aqt.qt import (  # pylint:disable=no-name-in-module
 from aqt.reviewer import RefreshNeeded
 from aqt.utils import tooltip
 
-from . import ankimorphs_config
+from . import ankimorphs_config, ankimorphs_globals
 from .ankimorphs_config import AnkiMorphsConfig, AnkiMorphsConfigFilter
 from .ankimorphs_db import AnkiMorphsDB
 from .ui.view_morphs_dialog_ui import Ui_ViewMorphsDialog
@@ -118,6 +118,23 @@ def browse_same_morphs(  # pylint:disable=too-many-arguments
     query = focus_query(am_config, card_ids, search_ready_tag)
     browser = dialogs.open("Browser", mw)
     assert browser is not None
+
+    search_edit: Optional[QLineEdit] = browser.form.searchEdit.lineEdit()
+    assert search_edit is not None
+
+    search_edit.setText(query)
+    browser.onSearchActivated()
+
+
+def browse_highlighted_morph(selected_text: str) -> None:
+    # Find all cards that have the am-unknowns field equal to the
+    # selected text. Unlike browse_same_morphs which looks for card
+    # ids of cards in the AnkiMorphsDB, this function does a query
+    # for the text
+
+    browser = dialogs.open("Browser", mw)
+    assert browser is not None
+    query = f'"{ankimorphs_globals.EXTRA_FIELD_UNKNOWNS}:{selected_text}"'
 
     search_edit: Optional[QLineEdit] = browser.form.searchEdit.lineEdit()
     assert search_edit is not None


### PR DESCRIPTION
https://github.com/mortii/anki-morphs/issues/187

When studying, be able to highlight text on the card and have the pulldown menu to browse cards that have that text in am-unknowns.

## What is the new behavior?
The desired behavior is that when the option is selected, the card browser will come into focus with a query to find cards with the highlighted text.

There are at least 2 bugs in the code right now:
1. It does the search as soon as you right click to get the dropdown. I don't know how to use the trigger.
2. The query ought to have quotes around it, in case there are spaces in either the quoted text or the field name. I tried to do this by adding quotes in the f-string, doing it without an f-string, and using re.escape. I really thought re.escape should work, but it only escaped the hyphen in "am-unknowns" and didn't include the quotes.

## What kind of changes does this PR introduce?
This shouldn't change any other functionality.

[//]: # (Set items to checked like this: [x])

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [ ] My code successfully passes pre-commit
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I am willing to help create documentation/guides for the changes made in this PR
- [ ] This PR can be rebased onto main without conflicts (create a backup branch before attempting a rebase)
- [ ] I have squashed my commits into sensible portions
