### PR TITLE
Fix am-known-automatically not being assigned properly

### DIFF
--- a/ankimorphs/recalc.py
+++ b/ankimorphs/recalc.py
@@ -731,7 +731,7 @@ def _get_card_score_and_unknowns_and_learning_status(
 
         if morph.highest_learning_interval == 0:
             unknown_morphs.append(morph)
-        elif morph.highest_learning_interval <= am_config.recalc_interval_for_known:
+        elif morph.highest_learning_interval < am_config.recalc_interval_for_known:
             has_learning_morph = True
 
         if morph.lemma_and_inflection not in morph_priority:


### PR DESCRIPTION
Fixes an issue where `am-known-automatically` was not being applied to new cards with all known morphemes in cases where the card contained at least one morpheme that was manually set as known or loaded from the known-morphs folder.

## What is the current behavior?

Known morphs loaded from the known-morphs folder are being assigned a `highest_learning_interval` of `am_config.recalc_interval_for_known` ([L372](https://github.com/mortii/anki-morphs/blob/d7e76f58ad35064e91b3b59d9326b2caf38eace1/ankimorphs/recalc.py#L372)). However, this caused such morphs to be considered 'in learning' inside the function `_get_card_score_and_unknowns_and_learning_status` since it checks for intervals that are lower _or equal_ that value ([L734](https://github.com/mortii/anki-morphs/blob/d7e76f58ad35064e91b3b59d9326b2caf38eace1/ankimorphs/recalc.py#L734)).

This resulted in a situation where new cards with all known morphs, where at least some of them were loaded from the known-morphs folder, were considered to have learning morphs in them, preventing the card from getting tagged with `am-known-automatically` even though all of its morphs were known.

## What is the new behavior?

For the purpose of tagging a new card, morphs are now considered to be 'in learning' when their highest learning interval is _strictly less_ than the "learning interval of known morphs" set in the configuration.

New cards containing only known morphs, regardless of how they got their 'known' status, will now be properly tagged with `am-known-automatically`.

## What kind of changes does this PR introduce?

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code successfully passes pre-commit
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I am willing to help create documentation/guides for the changes made in this PR
- [x] This PR can be rebased onto main without conflicts (create a backup branch before attempting a rebase)
- [x] I have squashed my commits into sensible portions
