### PR TITLE
Fixed morph priority bug

### DIFF
--- a/ankimorphs/recalc/card_morphs_metrics.py
+++ b/ankimorphs/recalc/card_morphs_metrics.py
@@ -63,10 +63,11 @@ class CardMorphsMetrics:
         morph_priorities: dict[str, int],
         card_morphs: list[Morpheme],
     ) -> None:
-        morph_priority = default_morph_priority
 
         for morph in card_morphs:
             assert morph.highest_lemma_learning_interval is not None
+
+            morph_priority = default_morph_priority
 
             key = morph.lemma + morph.lemma
             if key in morph_priorities:
@@ -90,10 +91,11 @@ class CardMorphsMetrics:
         morph_priorities: dict[str, int],
         card_morphs: list[Morpheme],
     ) -> None:
-        morph_priority = default_morph_priority
 
         for morph in card_morphs:
             assert morph.highest_inflection_learning_interval is not None
+
+            morph_priority = default_morph_priority
 
             key = morph.lemma + morph.inflection
             if key in morph_priorities:


### PR DESCRIPTION
First of all, thanks so much for your work on this excellent plugin! I'm really looking forward to the release of v3!

## What is the current behavior?

The v3 branch is not determining morph priority correctly in the `_process_using_*` functions, as the morph priority was not being reset each time through the loop. 

## What is the new behavior?

Morph priority is initialized to the default morph priority within the loops, rather than once outside the loops.

## What kind of changes does this PR introduce?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
