### PR TITLE
Slight change to get_morph_priorities_from_collection call

### DIFF
--- a/ankimorphs/ankimorphs_db.py
+++ b/ankimorphs/ankimorphs_db.py
@@ -471,7 +471,7 @@ class AnkiMorphsDB:  # pylint:disable=too-many-public-methods
     # the cache needs to have a max size to maintain garbage collection
     @functools.lru_cache(maxsize=131072)
     def get_morph_priorities_from_collection(
-        self, am_config: AnkiMorphsConfig
+        self, only_lemma_priorities: bool
     ) -> dict[tuple[str, str], int]:
         # Sorting the morphs (ORDER BY) is crucial to avoid bugs
         morphs_query = self.con.execute(
@@ -484,7 +484,7 @@ class AnkiMorphsDB:  # pylint:disable=too-many-public-methods
 
         intermediate_morph_list = []
 
-        if am_config.evaluate_morph_lemma:
+        if only_lemma_priorities:
             for lemma, _ in morphs_query:
                 intermediate_morph_list.append((lemma, lemma))
         else:

--- a/ankimorphs/recalc/morph_priority_utils.py
+++ b/ankimorphs/recalc/morph_priority_utils.py
@@ -48,7 +48,9 @@ def _get_morph_priority(
     am_config_filter: AnkiMorphsConfigFilter,
 ) -> dict[tuple[str, str], int]:
     if am_config_filter.morph_priority_selection == am_globals.COLLECTION_FREQUENCY_OPTION:  # fmt: skip
-        return am_db.get_morph_priorities_from_collection(am_config)
+        return am_db.get_morph_priorities_from_collection(
+            only_lemma_priorities=am_config.evaluate_morph_lemma
+        )
 
     return _load_morph_priorities_from_file(
         frequency_file_name=am_config_filter.morph_priority_selection,


### PR DESCRIPTION
I'd like to propose a slight change to `get_morph_priorities_from_collection`'s signature:

**Old**
```python
def get_morph_priorities_from_collection(
        self, am_config: AnkiMorphsConfig
 ) -> dict[tuple[str, str], int]
```

**New**
```python
def get_morph_priorities_from_collection(
        self, only_lemma_priorities: bool
 ) -> dict[tuple[str, str], int]:
```

By just passing our desired ``only_lemma_priorities``, we can generate priorities from the collection without needing to pass in the current configuration. This is convenient for the progression window, where the user - regardless of the config - can gauge progress according to collection lemmas or collection inflections.

This also gives better consistency between ``get_morph_priorities_from_collection`` and ``_load_morph_priorities_from_file``.
