### PR TITLE
bugfix: avoid deeply nested SQL query which can crash

### DIFF
--- a/ankimorphs/ankimorphs_db.py
+++ b/ankimorphs/ankimorphs_db.py
@@ -622,10 +622,7 @@ class AnkiMorphsDB:  # pylint:disable=too-many-public-methods
 
         where_query_string = ""
         if len(cards_studied_today) > 0:
-            where_query_string = "WHERE" + "".join(
-                [f" card_id = {card_id} OR" for card_id in cards_studied_today]
-            )
-            where_query_string = where_query_string[:-3]  # removes the last " OR"
+            where_query_string = "WHERE card_id IN (" + ",".join(map(str, cards_studied_today)) + ")"
 
         am_db.drop_seen_morphs_table()
         am_db.create_seen_morph_table()


### PR DESCRIPTION
## What is the current behavior?

When opening a deck or reviewing a card in a deck which has seen many new cards today, `rebuild_seen_morphs_today_background` causes an SQL crash. This is because this function produces a query with a deeply nested `OR` expression, breaking the SQL parser.

```
Anki 24.06.3 (d678e393)  (ao)
Python 3.9.18 Qt 6.6.2 PyQt 6.6.1
Platform: macOS-13.6.7-arm64-arm-64bit

Traceback (most recent call last):
  File "aqt.taskman", line 142, in _on_closures_pending
  File "aqt.taskman", line 86, in <lambda>
  File "aqt.taskman", line 106, in wrapped_done
  File "aqt.operations", line 252, in wrapped_done
  File "/Users/jon/Dropbox (Personal)/Anki/addons21/472573498/ankimorphs_db.py", line 707, in _on_failure
    raise error
  File "concurrent.futures.thread", line 58, in run
  File "aqt.operations", line 242, in wrapped_op
  File "/Users/jon/Dropbox (Personal)/Anki/addons21/472573498/ankimorphs_db.py", line 608, in <lambda>
    op=lambda _: AnkiMorphsDB.rebuild_seen_morphs_today_background(),
  File "/Users/jon/Dropbox (Personal)/Anki/addons21/472573498/ankimorphs_db.py", line 636, in rebuild_seen_morphs_today_background
    am_db.con.execute(
sqlite3.OperationalError: Expression tree is too large (maximum depth 1000)
```

## What is the new behavior?

I've updated the query to use an `IN` expression instead, which doesn't break the parser even with large numbers of values.

## What kind of changes does this PR introduce?

N/A

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [x] My code successfully passes pre-commit
- N/A I have commented my code, particularly in hard-to-understand areas
- [x] I am willing to help create documentation/guides for the changes made in this PR
- [x] This PR can be rebased onto main without conflicts (create a backup branch before attempting a rebase)
- N/A I have squashed my commits into sensible portions
