### PR TITLE
Fix for the custom card reviewer being in conflict with other addons

### DIFF
--- a/ankimorphs/__init__.py
+++ b/ankimorphs/__init__.py
@@ -324,7 +324,16 @@ def replace_card_reviewer() -> None:
 
     reviewing_utils.init_undo_targets()
 
-    mw.reviewer.nextCard = reviewing_utils.am_next_card
+    # Next card
+    old_next_card = mw.reviewer.nextCard
+
+    def new_next_card():
+        reviewing_utils.am_next_card()  # Custom AM next card
+        return old_next_card()          # then fallback to original
+
+    mw.reviewer.nextCard = new_next_card
+
+    # Shortcut keys
     mw.reviewer._shortcutKeys = partial(
         reviewing_utils.am_reviewer_shortcut_keys,
         self=mw.reviewer,

--- a/ankimorphs/__init__.py
+++ b/ankimorphs/__init__.py
@@ -327,9 +327,9 @@ def replace_card_reviewer() -> None:
     # Next card
     old_next_card = mw.reviewer.nextCard
 
-    def new_next_card():
+    def new_next_card() -> None:
         reviewing_utils.am_next_card()  # Custom AM next card
-        return old_next_card()          # then fallback to original
+        old_next_card()                 # then fallback to original
 
     mw.reviewer.nextCard = new_next_card
 


### PR DESCRIPTION
## What is the current behavior?

The card reviewer could be in conflict with some other addons that also edits the next card reviewer.

Issue: #326 

## What is the new behavior?

The other addon is now working correctly with Ankimorphs.

## What kind of changes does this PR introduce?

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [ ] My code successfully passes pre-commit
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I am willing to help create documentation/guides for the changes made in this PR
- [ ] This PR can be rebased onto main without conflicts (create a backup branch before attempting a rebase)
- [x] I have squashed my commits into sensible portions
- [ ] **Need to check if everything is really working on the review page** (I am new to the addon so I dont really know what to try...)
