### PR TITLE
Reduce redundant work in recalc's caching and morph priorities

### DIFF
--- a/ankimorphs/ankimorphs_db.py
+++ b/ankimorphs/ankimorphs_db.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import functools
 import sqlite3
-from collections import Counter
 from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
@@ -442,6 +441,9 @@ class AnkiMorphsDB:  # pylint:disable=too-many-public-methods
     def get_card_morph_map_cache(self) -> dict[int, list[Morpheme]]:
         card_morph_map_cache: dict[int, list[Morpheme]] = {}
 
+        # the same morph is on many cards, and sharing one object per morph
+        interned_morphs: dict[tuple[str, str], Morpheme] = {}
+
         # Sorting the morphs (ORDER BY) is crucial to avoid bugs
         card_morph_map_cache_raw = self.con.execute(
             """
@@ -455,12 +457,17 @@ class AnkiMorphsDB:  # pylint:disable=too-many-public-methods
 
         for row in card_morph_map_cache_raw:
             card_id = row[0]
-            morph = Morpheme(
-                lemma=row[1],
-                inflection=row[2],
-                highest_lemma_learning_interval=row[3],
-                highest_inflection_learning_interval=row[4],
-            )
+            morph_key = (row[1], row[2])
+            morph = interned_morphs.get(morph_key)
+
+            if morph is None:
+                morph = Morpheme(
+                    lemma=row[1],
+                    inflection=row[2],
+                    highest_lemma_learning_interval=row[3],
+                    highest_inflection_learning_interval=row[4],
+                )
+                interned_morphs[morph_key] = morph
 
             if card_id not in card_morph_map_cache:
                 card_morph_map_cache[card_id] = [morph]
@@ -510,37 +517,40 @@ class AnkiMorphsDB:  # pylint:disable=too-many-public-methods
     def get_morph_priorities_from_collection(
         self, only_lemma_priorities: bool
     ) -> dict[tuple[str, str], int]:
-        # Sorting the morphs (ORDER BY) is crucial to avoid bugs
-        morphs_query = self.con.execute(
-            """
-            SELECT morph_lemma, morph_inflection
-            FROM Card_Morph_Map
-            ORDER BY morph_lemma, morph_inflection
-            """,
-        ).fetchall()
-
-        intermediate_morph_list = []
-
+        # ties are broken alphabetically, which is the order Counter.most_common()
+        # produced here before, so the priorities stay deterministic
         if only_lemma_priorities:
-            for lemma, _ in morphs_query:
-                intermediate_morph_list.append((lemma, lemma))
+            morphs_sorted_by_amount: list[tuple[str, str]] = [
+                (lemma, lemma)
+                for lemma, _occurrences in self.con.execute(
+                    """
+                    SELECT morph_lemma, COUNT(*) AS occurrences
+                    FROM Card_Morph_Map
+                    GROUP BY morph_lemma
+                    ORDER BY occurrences DESC, morph_lemma
+                    """,
+                ).fetchall()
+            ]
         else:
-            for lemma, inflection in morphs_query:
-                intermediate_morph_list.append((lemma, inflection))
-
-        morphs_sorted_amount: dict[tuple[str, str], int] = dict(
-            Counter(intermediate_morph_list).most_common()
-        )
-
-        morph_priorities: dict[tuple[str, str], int] = {}
+            morphs_sorted_by_amount = [
+                (lemma, inflection)
+                for lemma, inflection, _occurrences in self.con.execute(
+                    """
+                    SELECT morph_lemma, morph_inflection, COUNT(*) AS occurrences
+                    FROM Card_Morph_Map
+                    GROUP BY morph_lemma, morph_inflection
+                    ORDER BY occurrences DESC, morph_lemma, morph_inflection
+                    """,
+                ).fetchall()
+            ]
 
         # Reverse the values, the lower the priority number is, the more it is prioritized.
         # Note: we can use a shortcut of providing the same priority (index) for both
         # the lemma and the inflection since we generate the intermediate lists from
         # scratch every recalc, so whichever ends up being used will have the correct value.
-        for index, key in enumerate(morphs_sorted_amount):
-            morph_priorities[key] = index
-            # print(f"key: {key}, index: {index}")
+        morph_priorities: dict[tuple[str, str], int] = {
+            key: index for index, key in enumerate(morphs_sorted_by_amount)
+        }
 
         return morph_priorities
 

--- a/ankimorphs/recalc/caching.py
+++ b/ankimorphs/recalc/caching.py
@@ -55,6 +55,8 @@ def cache_anki_data(
         progress_utils.background_update_progress(label="Importing known morphs")
         morph_table_data += _get_morphs_from_files(am_config)
 
+    morph_table_data = _deduplicate_morphs(morph_table_data)
+
     progress_utils.background_update_progress(label="Updating learning intervals")
     _update_learning_intervals(am_config, morph_table_data)
 
@@ -151,6 +153,27 @@ def _append_card_and_morph_data(  # pylint:disable=too-many-arguments)
                     "morph_inflection": morph.inflection,
                 }
             )
+
+
+def _deduplicate_morphs(
+    morph_table_data: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    # the Morphs table only keeps one row per (lemma, inflection) with the
+    # highest interval anyway, so collapsing here just saves sqlite the upserts
+    deduplicated_morphs: dict[tuple[str, str], dict[str, Any]] = {}
+
+    for morph_data_dict in morph_table_data:
+        key = (morph_data_dict["lemma"], morph_data_dict["inflection"])
+        existing = deduplicated_morphs.get(key)
+
+        if (
+            existing is None
+            or morph_data_dict["highest_inflection_learning_interval"]
+            > existing["highest_inflection_learning_interval"]
+        ):
+            deduplicated_morphs[key] = morph_data_dict
+
+    return list(deduplicated_morphs.values())
 
 
 def _get_card_memory_strength(


### PR DESCRIPTION
## What is the current behavior?

Recalc does unnecessary work:

- `_append_card_and_morph_data()` inserts a row for every `<card, morph>` pair (235,279 rows for only 14,302 unique morphs). It sends all of them to SQLite with `ON CONFLICT ... DO UPDATE` to deduplicate them on write.
- `get_card_morph_map_cache()` creates a new `Morpheme` object for every row, creating thousands of duplicate instances. Because `Morpheme.get_learning_status()` uses an `lru_cache` keyed on `self`, it never gets cache hits and fills up memory with duplicate entries.
- `get_morph_priorities_from_collection()` loads the entire `Card_Morph_Map` table into Python and counts it with `Counter`, building a 235,279-item list in memory just to produce 14,302 results.

## What is the new behavior?

- Morph rows are deduplicated by `(lemma, inflection)` in Python before insertion, keeping the highest inflection interval. This produces the exact same table as the SQL `ON CONFLICT` clause did (0.71s -> 0.05s).
- Creates only one `Morpheme` object per unique morph and shares it across cards as read-only. `Morpheme.get_learning_status()` now gets cache hits, which also speeds up highlighting.
- SQLite handles counting and ordering priorities directly with `GROUP BY`. Ties are broken alphabetically, matching the exact output of `Counter.most_common()`.

Measured on `big_japanese_collection`: **9.19s -> 7.94s (-14%)**.

## What kind of changes does this PR introduce?

- [x] Performance improvement (non-breaking, produces identical output)

## Checklist:

- [x] My code successfully passes pre-commit
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I am willing to help create documentation/guides for the changes made in this PR
- [x] This PR can be rebased onto main without conflicts (create a backup branch before attempting a rebase)
- [x] I have squashed my commits into sensible portions
