### PR TITLE
Speed up the readability report and the progression window

### DIFF
--- a/ankimorphs/ankimorphs_db.py
+++ b/ankimorphs/ankimorphs_db.py
@@ -386,6 +386,23 @@ class AnkiMorphsDB:  # pylint:disable=too-many-public-methods
             assert isinstance(highest_learning_interval, int)
             return highest_learning_interval
 
+    def get_all_highest_inflection_learning_intervals(
+        self,
+    ) -> dict[tuple[str, str], int]:
+        with self.con:
+            return {(row[0], row[1]): row[2] for row in self.con.execute("""
+                    SELECT lemma, inflection, highest_inflection_learning_interval
+                    FROM Morphs
+                    """).fetchall()}
+
+    def get_all_highest_lemma_learning_intervals(self) -> dict[str, int]:
+        with self.con:
+            return {row[0]: row[1] for row in self.con.execute("""
+                    SELECT lemma, MAX(highest_lemma_learning_interval)
+                    FROM Morphs
+                    GROUP BY lemma
+                    """).fetchall()}
+
     def get_morph_inflections_learning_statuses(self) -> dict[str, str]:
         morph_status_dict: dict[str, str] = {}
         am_config = AnkiMorphsConfig()

--- a/ankimorphs/generators/generators_utils.py
+++ b/ankimorphs/generators/generators_utils.py
@@ -129,42 +129,37 @@ class PreprocessOptions:  # pylint:disable=too-many-instance-attributes
         )
 
 
+def get_highest_learning_intervals(
+    am_config: AnkiMorphsConfig, am_db: AnkiMorphsDB
+) -> dict[Any, int]:
+    if am_config.evaluate_morph_inflection:
+        return dict(am_db.get_all_highest_inflection_learning_intervals())
+    return dict(am_db.get_all_highest_lemma_learning_intervals())
+
+
 def get_morph_stats_from_file(
     am_config: AnkiMorphsConfig,
-    am_db: AnkiMorphsDB,
+    highest_learning_intervals: dict[Any, int],
     file_morphs: dict[str, MorphOccurrence],
 ) -> FileMorphsStats:
     file_morphs_stats = FileMorphsStats()
-    highest_learning_interval: int | None
+    evaluate_morph_inflection = am_config.evaluate_morph_inflection
 
-    if am_config.evaluate_morph_inflection:
-        for morph_occurrence_object in file_morphs.values():
-            morph = morph_occurrence_object.morph
-            occurrence = morph_occurrence_object.occurrence
-            highest_learning_interval = am_db.get_highest_inflection_learning_interval(
-                morph
-            )
+    for morph_occurrence_object in file_morphs.values():
+        morph = morph_occurrence_object.morph
 
-            _update_file_morphs_stats(
-                file_morphs_stats=file_morphs_stats,
-                interval_for_known=am_config.interval_for_known_morphs,
-                morph=morph,
-                occurrence=occurrence,
-                highest_learning_interval=highest_learning_interval,
-            )
-    else:
-        for morph_occurrence_object in file_morphs.values():
-            morph = morph_occurrence_object.morph
-            occurrence = morph_occurrence_object.occurrence
-            highest_learning_interval = am_db.get_highest_lemma_learning_interval(morph)
+        if evaluate_morph_inflection:
+            key: Any = (morph.lemma, morph.inflection)
+        else:
+            key = morph.lemma
 
-            _update_file_morphs_stats(
-                file_morphs_stats=file_morphs_stats,
-                interval_for_known=am_config.interval_for_known_morphs,
-                morph=morph,
-                occurrence=occurrence,
-                highest_learning_interval=highest_learning_interval,
-            )
+        _update_file_morphs_stats(
+            file_morphs_stats=file_morphs_stats,
+            interval_for_known=am_config.interval_for_known_morphs,
+            morph=morph,
+            occurrence=morph_occurrence_object.occurrence,
+            highest_learning_interval=highest_learning_intervals.get(key),
+        )
 
     return file_morphs_stats
 

--- a/ankimorphs/generators/readability_report_generator.py
+++ b/ankimorphs/generators/readability_report_generator.py
@@ -80,10 +80,15 @@ def _populate_tables_with_report(
     # the global report will be presented as a "Total" file in the table
     global_report_morph_stats = FileMorphsStats()
 
+    # loaded once here instead of one query per morph per file
+    highest_learning_intervals = generators_utils.get_highest_learning_intervals(
+        am_config, am_db
+    )
+
     for row, input_file in enumerate(input_files):
         file_morphs = morph_occurrences_by_file[input_file]
         file_morphs_stats = generators_utils.get_morph_stats_from_file(
-            am_config, am_db, file_morphs
+            am_config, highest_learning_intervals, file_morphs
         )
         global_report_morph_stats += file_morphs_stats
 

--- a/ankimorphs/morpheme.py
+++ b/ankimorphs/morpheme.py
@@ -46,12 +46,7 @@ class Morpheme:
 
     def __eq__(self, other: object) -> bool:
         assert isinstance(other, Morpheme)
-        return all(
-            [
-                self.lemma == other.lemma,
-                self.inflection == other.inflection,
-            ]
-        )
+        return self.lemma == other.lemma and self.inflection == other.inflection
 
     def __hash__(self) -> int:
         return hash((self.lemma, self.inflection))

--- a/ankimorphs/progression/progression_utils.py
+++ b/ankimorphs/progression/progression_utils.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import bisect
+
 from ..ankimorphs_db import AnkiMorphsDB
 from ..exceptions import InvalidBinsException
 
@@ -103,29 +105,50 @@ def get_progress_reports(
     else:
         morph_learning_statuses = am_db.get_morph_inflections_learning_statuses()
 
-    for min_priority, max_priority in bins.indexes:
+    # sorted once so that every bin is a slice instead of a full re-filter
+    morphs_by_priority = sorted(morph_priorities.items(), key=lambda item: item[1])
+    sorted_priorities = [priority for _morph, priority in morphs_by_priority]
 
-        report = ProgressReport(min_priority, max_priority)
-        morph_priorities_subset = _get_morph_priorities_subset(
-            morph_priorities, min_priority, max_priority
+    for min_priority, max_priority in bins.indexes:
+        start = bisect.bisect_left(sorted_priorities, min_priority)
+        end = bisect.bisect_right(sorted_priorities, max_priority)
+
+        reports.append(
+            _build_progress_report(
+                min_priority=min_priority,
+                max_priority=max_priority,
+                morphs_in_range=morphs_by_priority[start:end],
+                morph_learning_statuses=morph_learning_statuses,
+                only_lemma_priorities=only_lemma_priorities,
+            )
         )
 
-        for morph in morph_priorities_subset:
-
-            learning_status_key = morph[0] + morph[1]
-            if only_lemma_priorities:
-                learning_status_key = morph[0]  # expect morph=(lemma,lemma)
-
-            morph_status = "missing"
-            if (
-                learning_status_key in morph_learning_statuses
-            ):  # if the morph is in the database
-                morph_status = morph_learning_statuses[learning_status_key]
-            _update_progress_report(report, morph, morph_status)
-
-        reports.append(report)
-
     return reports
+
+
+def _build_progress_report(
+    min_priority: int,
+    max_priority: int,
+    morphs_in_range: list[tuple[tuple[str, str], int]],
+    morph_learning_statuses: dict[str, str],
+    only_lemma_priorities: bool,
+) -> ProgressReport:
+    report = ProgressReport(min_priority, max_priority)
+
+    for morph, _priority in morphs_in_range:
+
+        learning_status_key = morph[0] + morph[1]
+        if only_lemma_priorities:
+            learning_status_key = morph[0]  # expect morph=(lemma,lemma)
+
+        morph_status = "missing"
+        if (
+            learning_status_key in morph_learning_statuses
+        ):  # if the morph is in the database
+            morph_status = morph_learning_statuses[learning_status_key]
+        _update_progress_report(report, morph, morph_status)
+
+    return report
 
 
 def get_priority_ordered_morph_statuses(


### PR DESCRIPTION
## What is the current behavior?

Three performance bottlenecks outside of recalc:

- `generators_utils.get_morph_stats_from_file()` calls `get_highest_inflection_learning_interval()` (or the lemma variant) once per morph, and `readability_report_generator` calls it once per file. Each call runs a separate query in its own transaction (e.g. 50 files × 2,000 morphs = 100,000 queries).
- `progression_utils._get_morph_priorities_subset()` filters the full morph priority dict for every bin, running in O(bins × morphs). For 50,000 morphs with a bin size of 500, that's ~5 million dict lookups to partition data that only needs to be sorted once.
- `Morpheme.__eq__` allocates a throwaway list (`all([a, b])`) on every comparison, running hundreds of thousands of times during dict and cache lookups.

## What is the new behavior?

- Preloads learning intervals into an in-memory dict (100,000 lookups on a file-backed DB: **0.95s -> 0.05s**).
- Sorts priorities once and slices bins with `bisect`, reducing complexity from O(bins × n) to O(n log n + bins).
- `Morpheme.__eq__` compares fields directly without allocating a list.

## What kind of changes does this PR introduce?

- [x] Performance improvement (non-breaking, produces identical output)

## Checklist:

- [x] My code successfully passes pre-commit
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I am willing to help create documentation/guides for the changes made in this PR
- [x] This PR can be rebased onto main without conflicts (create a backup branch before attempting a rebase)
- [x] I have squashed my commits into sensible portions