### PR TITLE
fix: don't crash on startup on anki 26.08+

### DIFF
--- a/ankimorphs/morphemizers/camel_wrapper.py
+++ b/ankimorphs/morphemizers/camel_wrapper.py
@@ -11,7 +11,8 @@ from typing import Any
 
 from anki.utils import is_win
 from aqt import mw
-from aqt.package import venv_binary
+
+from .python_binary import get_python_binary
 
 # pylint: disable=invalid-name,duplicate-code
 
@@ -138,10 +139,13 @@ def create_camel_venv() -> None:
 
     shutil.rmtree(camel_venv_path, ignore_errors=True)
 
-    python_path: str | None = venv_binary("python")
+    python_path: str | None = get_python_binary()
     if python_path is None:
         raise ValueError(
-            "Anki API error. Install Anki from the official website to avoid this issue."
+            "Could not find a python interpreter to create the CAMeL Tools"
+            " environment with. Anki 26.x is distributed as a self-contained app"
+            " that does not include one, so installing CAMeL Tools currently"
+            " requires Anki 25.09.x."
         )
 
     subprocess.run([python_path, "-m", "venv", camel_venv_path], check=True)

--- a/ankimorphs/morphemizers/python_binary.py
+++ b/ankimorphs/morphemizers/python_binary.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def get_python_binary() -> str | None:
+    """
+    Returns a python interpreter that can bootstrap the spaCy/CAMeL venvs,
+    or None if the anki install does not have one.
+
+    Anki 25.09 and earlier ran from a uv-managed venv and exposed its python
+    through 'aqt.package.venv_binary'. Anki 26.05 replaced the launcher with
+    briefcase packaging, and 26.08 removed that function, so we fall back to
+    the interpreter anki itself is running on. The official 26.x builds are
+    self-contained apps where sys.executable is the anki binary instead of a
+    python interpreter, and they have nothing we can create a venv with.
+    """
+    try:
+        # pylint:disable=import-outside-toplevel
+        from aqt.package import venv_binary
+    except ImportError:
+        pass
+    else:
+        launcher_python: str | None = venv_binary("python")
+        if launcher_python is not None:
+            return launcher_python
+
+    # we can't run sys.executable to determine whether it is a python
+    # interpreter, because doing that on a self-contained build launches
+    # another anki instance
+    if Path(sys.executable).name.lower().startswith("python"):
+        return sys.executable
+
+    return None

--- a/ankimorphs/morphemizers/spacy_wrapper.py
+++ b/ankimorphs/morphemizers/spacy_wrapper.py
@@ -11,7 +11,8 @@ from typing import Any
 
 from anki.utils import is_win
 from aqt import mw
-from aqt.package import venv_binary
+
+from .python_binary import get_python_binary
 
 # pylint: disable=invalid-name
 
@@ -173,11 +174,13 @@ def create_spacy_venv() -> None:
     # delete in case it already exists from previously failed attempts
     shutil.rmtree(spacy_venv_path, ignore_errors=True)
 
-    python_path: str | None = venv_binary("python")
+    python_path: str | None = get_python_binary()
 
     if python_path is None:
         raise ValueError(
-            "Anki API error. Install Anki from the official website to avoid this issue."
+            "Could not find a python interpreter to create the spaCy environment"
+            " with. Anki 26.x is distributed as a self-contained app that does not"
+            " include one, so installing spaCy currently requires Anki 25.09.x."
         )
 
     subprocess.run([python_path, "-m", "venv", spacy_venv_path], check=True)

--- a/test/tests/python_binary_test.py
+++ b/test/tests/python_binary_test.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import sys
+
+import aqt.package
+import pytest
+
+from ankimorphs.morphemizers.python_binary import get_python_binary
+
+
+def test_launcher_build_uses_the_anki_venv(monkeypatch: pytest.MonkeyPatch) -> None:
+    # anki 25.09 and earlier ran from a uv-managed venv
+    launcher_python = "/home/user/.local/share/AnkiProgramFiles/.venv/bin/python"
+    monkeypatch.setattr(aqt.package, "venv_binary", lambda cmd: launcher_python)
+    assert get_python_binary() == launcher_python
+
+
+@pytest.mark.parametrize(
+    "executable",
+    [
+        "/Applications/Anki.app/Contents/MacOS/Anki",
+        "/usr/local/anki",
+    ],
+)
+def test_self_contained_build_has_no_interpreter(
+    monkeypatch: pytest.MonkeyPatch, executable: str
+) -> None:
+    # anki 26.08 removed venv_binary, and the official builds run from a
+    # frozen binary we cannot create a venv with
+    monkeypatch.delattr(aqt.package, "venv_binary", raising=False)
+    monkeypatch.setattr(sys, "executable", executable)
+    assert get_python_binary() is None
+
+
+@pytest.mark.parametrize(
+    "executable",
+    [
+        "/app/bin/python3.13",
+        "/usr/bin/python3",
+    ],
+)
+def test_python_based_install_uses_the_running_interpreter(
+    monkeypatch: pytest.MonkeyPatch, executable: str
+) -> None:
+    monkeypatch.delattr(aqt.package, "venv_binary", raising=False)
+    monkeypatch.setattr(sys, "executable", executable)
+    assert get_python_binary() == executable


### PR DESCRIPTION
## What is the current behavior?

Anki 26.08 removed `aqt.package.venv_binary` together with the uv launcher (ankitects/anki#5019). `morphemizers/camel_wrapper.py` and `morphemizers/spacy_wrapper.py` import it at module scope, and `__init__.py` imports both unconditionally, so the whole add-on fails to load on 26.08 and later:

```
File ".../addons21/472573498/morphemizers/camel_wrapper.py", line 14, in <module>
    from aqt.package import venv_binary
ImportError: cannot import name 'venv_binary' from 'aqt.package'
```

Reported in #421 and on the AnkiWeb page. This hits every user on 26.08+, including those who only use the mecab, jieba or space morphemizers and never touch spaCy or CAMeL Tools.

## What is the new behavior?

A new `morphemizers/python_binary.py` resolves the interpreter used to bootstrap the spaCy and CAMeL venvs, and `create_spacy_venv()` / `create_camel_venv()` call it instead of importing the removed function:

1. `aqt.package.venv_binary("python")` when it exists, so 25.09 and earlier launcher builds behave exactly as before.
2. Otherwise `sys.executable`, when that is a real python interpreter. This covers flatpak, distro packages and pip installs, which is also the situation reported in #355.
3. Otherwise `None`, and the caller raises an error explaining that the self-contained 26.x builds ship no interpreter to create a venv with.

The add-on loads again on 26.08+. This does not claim to restore spaCy or CAMeL Tools installation on the official 26.x builds. Those bundles contain no python interpreter, so the managers now fail with an accurate message instead of the entire add-on failing at import time.

One note on the workaround circulating on the AnkiWeb page, which returns `sys.executable` unconditionally: on the official macOS and Windows builds `sys.executable` is the Anki binary itself, so `[sys.executable, "-m", "venv", path]` spawns a second Anki instance. That is why the fallback checks the executable name, which cannot be done by running it.

## Verification

- `__import__("ankimorphs")` against `aqt 26.8.1`: `ImportError` before the change, clean import after.
- Anki 26.8.1 (macOS briefcase build) on a scratch profile: the add-on loads and the toolbar shows `Recalc  L  I`, no startup error dialog.
- `aqt 25.9.4`: `venv_binary` is still used when present, so launcher builds are unaffected.
- New tests in `test/tests/python_binary_test.py` cover all three branches (5 cases, passing).
- black, isort, mypy and pylint pass on the changed files (pylint 10.00/10).

## What kind of changes does this PR introduce?

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code successfully passes pre-commit
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I am willing to help create documentation/guides for the changes made in this PR
- [x] This PR can be rebased onto main without conflicts (create a backup branch before attempting a rebase)
- [x] I have squashed my commits into sensible portions
