### PR TITLE
fix: install spaCy/CAMeL deps on anki 26.x by provisioning python with uv

### DIFF
--- a/ankimorphs/morphemizers/camel_wrapper.py
+++ b/ankimorphs/morphemizers/camel_wrapper.py
@@ -12,6 +12,7 @@ from typing import Any
 from anki.utils import is_win
 from aqt import mw
 
+from . import uv_bootstrap
 from .python_binary import get_python_binary
 
 # pylint: disable=invalid-name,duplicate-code
@@ -140,15 +141,13 @@ def create_camel_venv() -> None:
     shutil.rmtree(camel_venv_path, ignore_errors=True)
 
     python_path: str | None = get_python_binary()
-    if python_path is None:
-        raise ValueError(
-            "Could not find a python interpreter to create the CAMeL Tools"
-            " environment with. Anki 26.x is distributed as a self-contained app"
-            " that does not include one, so installing CAMeL Tools currently"
-            " requires Anki 25.09.x."
-        )
 
-    subprocess.run([python_path, "-m", "venv", camel_venv_path], check=True)
+    if python_path is not None:
+        subprocess.run([python_path, "-m", "venv", camel_venv_path], check=True)
+    else:
+        # official anki 26.x builds are self-contained apps without a usable
+        # python interpreter, so we download uv and have it provision one
+        uv_bootstrap.create_managed_venv(str(camel_venv_path))
 
     # create the data dir to prevent a crash (bug in camel tools)
     _get_am_camel_venv_data_path().mkdir()

--- a/ankimorphs/morphemizers/python_binary.py
+++ b/ankimorphs/morphemizers/python_binary.py
@@ -14,7 +14,8 @@ def get_python_binary() -> str | None:
     briefcase packaging, and 26.08 removed that function, so we fall back to
     the interpreter anki itself is running on. The official 26.x builds are
     self-contained apps where sys.executable is the anki binary instead of a
-    python interpreter, and they have nothing we can create a venv with.
+    python interpreter. When this returns None, uv_bootstrap downloads a
+    standalone interpreter instead.
     """
     try:
         # pylint:disable=import-outside-toplevel

--- a/ankimorphs/morphemizers/spacy_wrapper.py
+++ b/ankimorphs/morphemizers/spacy_wrapper.py
@@ -12,6 +12,7 @@ from typing import Any
 from anki.utils import is_win
 from aqt import mw
 
+from . import uv_bootstrap
 from .python_binary import get_python_binary
 
 # pylint: disable=invalid-name
@@ -176,14 +177,12 @@ def create_spacy_venv() -> None:
 
     python_path: str | None = get_python_binary()
 
-    if python_path is None:
-        raise ValueError(
-            "Could not find a python interpreter to create the spaCy environment"
-            " with. Anki 26.x is distributed as a self-contained app that does not"
-            " include one, so installing spaCy currently requires Anki 25.09.x."
-        )
-
-    subprocess.run([python_path, "-m", "venv", spacy_venv_path], check=True)
+    if python_path is not None:
+        subprocess.run([python_path, "-m", "venv", spacy_venv_path], check=True)
+    else:
+        # official anki 26.x builds are self-contained apps without a usable
+        # python interpreter, so we download uv and have it provision one
+        uv_bootstrap.create_managed_venv(spacy_venv_path)
 
     if is_win:
         spacy_venv_python = os.path.join(spacy_venv_path, "Scripts", "python.exe")

--- a/ankimorphs/morphemizers/uv_bootstrap.py
+++ b/ankimorphs/morphemizers/uv_bootstrap.py
@@ -28,6 +28,7 @@ import shutil
 import subprocess
 import sys
 import tarfile
+import tempfile
 import zipfile
 from pathlib import Path
 
@@ -136,14 +137,16 @@ def _find_native_uv() -> str | None:
 
 def _probe_python(argv_prefix: list[str]) -> str | None:
     """
-    Returns the interpreter's path if it matches the python version and
-    architecture of the anki process, otherwise None.
+    Returns the interpreter's path if it is a regular CPython matching the
+    python version and architecture of the anki process, otherwise None.
     """
     probe_code = (
-        "import platform, sys\n"
+        "import platform, sys, sysconfig\n"
         "print(sys.version_info.major)\n"
         "print(sys.version_info.minor)\n"
         "print(platform.machine())\n"
+        "print(sys.implementation.name)\n"
+        "print(sysconfig.get_config_var('Py_GIL_DISABLED') or 0)\n"
         "print(sys.executable)\n"
     )
     try:
@@ -158,15 +161,19 @@ def _probe_python(argv_prefix: list[str]) -> str | None:
         return None
 
     lines = result.stdout.splitlines()
-    if len(lines) < 4:
+    if len(lines) < 6:
         return None
-    if lines[0] != str(sys.version_info.major):
+
+    expected = [
+        str(sys.version_info.major),
+        str(sys.version_info.minor),
+        platform.machine(),
+        "cpython",  # pypy venvs would select wheels anki cannot import
+        "0",  # free-threaded builds use incompatible cp3XXt wheels
+    ]
+    if lines[:5] != expected:
         return None
-    if lines[1] != str(sys.version_info.minor):
-        return None
-    if lines[2] != platform.machine():
-        return None
-    return lines[3].strip() or None
+    return lines[5].strip() or None
 
 
 def _find_native_python() -> str | None:
@@ -242,13 +249,19 @@ def _extract_uv_binary(archive: bytes, asset_name: str, destination: Path) -> No
             f"The downloaded archive {asset_name} did not contain a uv binary."
         )
 
-    # write to a temp file and rename so interrupted installs never leave a
-    # half-written binary behind
-    temp_destination = destination.with_suffix(".tmp")
-    temp_destination.write_bytes(binary)
-    if not is_win:
-        temp_destination.chmod(0o755)
-    os.replace(temp_destination, destination)
+    # write to a unique temp file and rename into place so interrupted or
+    # concurrent installs never leave a half-written binary behind
+    temp_fd, temp_name = tempfile.mkstemp(dir=destination.parent, suffix=".tmp")
+    temp_destination = Path(temp_name)
+    try:
+        with os.fdopen(temp_fd, "wb") as temp_file:
+            temp_file.write(binary)
+        if not is_win:
+            temp_destination.chmod(0o755)
+        os.replace(temp_destination, destination)
+    finally:
+        # gone already unless writing or renaming failed
+        temp_destination.unlink(missing_ok=True)
 
 
 def ensure_uv() -> str:
@@ -269,6 +282,26 @@ def ensure_uv() -> str:
     uv_path.parent.mkdir(parents=True, exist_ok=True)
     _extract_uv_binary(archive, asset_name, uv_path)
     return str(uv_path)
+
+
+def _uv_python_request() -> str:
+    """
+    An architecture-qualified python request (e.g. 'cpython-3.13-macos-
+    aarch64-none') instead of a bare '3.13', so that uv provisions an
+    interpreter matching the anki process even when the uv binary itself
+    runs under a different architecture (e.g. a native arm64 uv while anki
+    is an intel build running under rosetta).
+    """
+    python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
+    machine = platform.machine().lower()
+    arch = {"amd64": "x86_64", "arm64": "aarch64"}.get(machine, machine)
+    if sys.platform == "darwin":
+        os_name, libc = "macos", "none"
+    elif sys.platform == "win32":
+        os_name, libc = "windows", "none"
+    else:
+        os_name, libc = "linux", "gnu"
+    return f"cpython-{python_version}-{os_name}-{arch}-{libc}"
 
 
 def create_managed_venv(venv_path: str) -> None:
@@ -311,7 +344,7 @@ def create_managed_venv(venv_path: str) -> None:
             "--managed-python",
             "--no-config",
             "--python",
-            f"{sys.version_info.major}.{sys.version_info.minor}",
+            _uv_python_request(),
             venv_path,
         ],
         check=True,

--- a/ankimorphs/morphemizers/uv_bootstrap.py
+++ b/ankimorphs/morphemizers/uv_bootstrap.py
@@ -1,0 +1,318 @@
+"""
+Provisions a python interpreter for the spaCy/CAMeL venvs when the anki
+install does not have one we can use.
+
+Anki 25.09 and earlier ran from a uv-managed venv and exposed its python
+through 'aqt.package.venv_binary', so get_python_binary() could return an
+interpreter. The official Anki 26.x builds are self-contained apps without a
+usable interpreter, so we have to provision one ourselves. To avoid
+unnecessary downloads we first look for tools already installed on the
+system: a CPython matching the version anki runs on (used directly with
+'python -m venv'), then a usable uv binary. Only when neither exists do we
+download a pinned uv release (sha256 verified) into a bootstrap folder next
+to the venvs, and have uv install a standalone CPython.
+
+Note: the available python versions are frozen per uv release, so if anki
+ever adopts a CPython minor unknown to the pinned uv version below (0.12.7
+knows 3.13 and 3.14), bump _UV_VERSION and the _UV_ASSETS digests.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import os
+import platform
+import re
+import shutil
+import subprocess
+import sys
+import tarfile
+import zipfile
+from pathlib import Path
+
+from anki.httpclient import HttpClient
+from anki.utils import is_mac, is_win
+from aqt import mw
+
+_UV_VERSION = "0.12.7"
+_UV_RELEASE_URL = f"https://github.com/astral-sh/uv/releases/download/{_UV_VERSION}/"
+
+# the oldest uv that supports every flag we pass to 'uv venv'
+# (--managed-python was the last one added, in uv 0.6.8)
+_MIN_NATIVE_UV_VERSION = (0, 6, 8)
+
+# (sys.platform, platform.machine().lower()) -> (asset name, sha256 hex digest)
+# digests taken from the github release api for uv 0.12.7
+_UV_ASSETS: dict[tuple[str, str], tuple[str, str]] = {
+    ("darwin", "arm64"): (
+        "uv-aarch64-apple-darwin.tar.gz",
+        "127ebdda7ad953cdf198e964b570ea5771b85467ea93eb7cb6d6f8e6f55408f3",
+    ),
+    ("darwin", "x86_64"): (
+        "uv-x86_64-apple-darwin.tar.gz",
+        "06b8ae1da8c2661c5434507a66f8c2b0b835933bf955b5958a9ac357a37d1959",
+    ),
+    ("win32", "amd64"): (
+        "uv-x86_64-pc-windows-msvc.zip",
+        "bf1518af459a3915511a11fdc6e2f43ef9a2afa138b9d498eeb9642fe9d85218",
+    ),
+    ("win32", "arm64"): (
+        "uv-aarch64-pc-windows-msvc.zip",
+        "1611d0f4be72b0a354ad9a6ae954093dd4c91e93e36b8b490326a05a039ffe14",
+    ),
+    ("linux", "x86_64"): (
+        "uv-x86_64-unknown-linux-gnu.tar.gz",
+        "788f18abea7c5f55d6216e4f5613fd89d4d59b631efeec117b2b07fe72f1da21",
+    ),
+    ("linux", "aarch64"): (
+        "uv-aarch64-unknown-linux-gnu.tar.gz",
+        "66393193038dd7eb108abd7a218d9cec04ac70ab98242b0720fa94de19223b7c",
+    ),
+}
+
+
+def _bootstrap_dir() -> Path:
+    # a sibling of the addon dir, just like the venvs, so it survives updates
+    return Path(mw.pm.addonFolder(), "ankimorphs-python-bootstrap")
+
+
+def _extra_search_dirs() -> list[str]:
+    # anki inherits a minimal PATH when launched from the desktop, so
+    # searching PATH alone would miss most user-installed tools
+    home = Path.home()
+    if is_win:
+        return [str(home / ".local" / "bin")]
+    dirs = [
+        str(home / ".local" / "bin"),
+        str(home / ".cargo" / "bin"),
+        "/usr/local/bin",
+        "/usr/bin",
+    ]
+    if is_mac:
+        python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
+        dirs += [
+            "/opt/homebrew/bin",
+            f"/Library/Frameworks/Python.framework/Versions/{python_version}/bin",
+        ]
+    return dirs
+
+
+def _which(command: str) -> str | None:
+    path_dirs = [
+        directory
+        for directory in os.environ.get("PATH", "").split(os.pathsep)
+        if directory
+    ]
+    return shutil.which(command, path=os.pathsep.join(path_dirs + _extra_search_dirs()))
+
+
+def _uv_version(version_output: str) -> tuple[int, int, int] | None:
+    match = re.match(r"uv (\d+)\.(\d+)\.(\d+)", version_output)
+    if match is None:
+        return None
+    return (int(match[1]), int(match[2]), int(match[3]))
+
+
+def _find_native_uv() -> str | None:
+    uv_path = _which("uv")
+    if uv_path is None:
+        return None
+    try:
+        result = subprocess.run(
+            [uv_path, "--version"],
+            check=True,
+            text=True,
+            capture_output=True,
+            timeout=15,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    version = _uv_version(result.stdout)
+    if version is None or version < _MIN_NATIVE_UV_VERSION:
+        return None
+    return uv_path
+
+
+def _probe_python(argv_prefix: list[str]) -> str | None:
+    """
+    Returns the interpreter's path if it matches the python version and
+    architecture of the anki process, otherwise None.
+    """
+    probe_code = (
+        "import platform, sys\n"
+        "print(sys.version_info.major)\n"
+        "print(sys.version_info.minor)\n"
+        "print(platform.machine())\n"
+        "print(sys.executable)\n"
+    )
+    try:
+        result = subprocess.run(
+            [*argv_prefix, "-c", probe_code],
+            check=True,
+            text=True,
+            capture_output=True,
+            timeout=15,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+    lines = result.stdout.splitlines()
+    if len(lines) < 4:
+        return None
+    if lines[0] != str(sys.version_info.major):
+        return None
+    if lines[1] != str(sys.version_info.minor):
+        return None
+    if lines[2] != platform.machine():
+        return None
+    return lines[3].strip() or None
+
+
+def _find_native_python() -> str | None:
+    python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
+    argv_prefixes: list[list[str]] = []
+
+    if is_win:
+        # the py launcher is the canonical way to locate CPython on windows
+        py_launcher = _which("py")
+        if py_launcher is not None:
+            argv_prefixes.append([py_launcher, f"-{python_version}"])
+
+    versioned_binary = _which(f"python{python_version}")
+    if versioned_binary is not None:
+        argv_prefixes.append([versioned_binary])
+
+    for argv_prefix in argv_prefixes:
+        executable = _probe_python(argv_prefix)
+        if executable is not None:
+            return executable
+
+    return None
+
+
+def _uv_asset(platform_name: str, machine: str) -> tuple[str, str]:
+    try:
+        return _UV_ASSETS[(platform_name, machine)]
+    except KeyError as error:
+        raise RuntimeError(
+            f"AnkiMorphs does not have a Python download for this platform"
+            f" ({platform_name} {machine}). Please report this on the"
+            f" AnkiMorphs github page."
+        ) from error
+
+
+def _download(url: str) -> bytes:
+    try:
+        client = HttpClient()
+        response = client.get(url)
+        return client.stream_content(response)
+    except Exception as error:  # pylint:disable=broad-exception-caught
+        raise RuntimeError(
+            f"Downloading {url} failed. Check your internet connection and try again."
+        ) from error
+
+
+def _extract_uv_binary(archive: bytes, asset_name: str, destination: Path) -> None:
+    # the zip has uv.exe at its root and the tarball nests uv inside a
+    # uv-<target>/ directory, so we search by basename to tolerate layout
+    # drift in future uv releases
+    binary: bytes | None = None
+
+    if asset_name.endswith(".zip"):
+        with zipfile.ZipFile(io.BytesIO(archive)) as zip_file:
+            for zip_name in zip_file.namelist():
+                if os.path.basename(zip_name) == "uv.exe":
+                    binary = zip_file.read(zip_name)
+                    break
+    else:
+        with tarfile.open(fileobj=io.BytesIO(archive), mode="r:gz") as tar_file:
+            for member in tar_file.getmembers():
+                if os.path.basename(member.name) == "uv":
+                    extracted = tar_file.extractfile(member)
+                    if extracted is not None:
+                        binary = extracted.read()
+                    break
+
+    if binary is None:
+        raise RuntimeError(
+            f"The downloaded archive {asset_name} did not contain a uv binary."
+        )
+
+    # write to a temp file and rename so interrupted installs never leave a
+    # half-written binary behind
+    temp_destination = destination.with_suffix(".tmp")
+    temp_destination.write_bytes(binary)
+    if not is_win:
+        temp_destination.chmod(0o755)
+    os.replace(temp_destination, destination)
+
+
+def ensure_uv() -> str:
+    uv_path = _bootstrap_dir() / "uv" / ("uv.exe" if is_win else "uv")
+
+    if uv_path.exists():
+        return str(uv_path)
+
+    asset_name, expected_digest = _uv_asset(sys.platform, platform.machine().lower())
+    archive = _download(_UV_RELEASE_URL + asset_name)
+
+    if hashlib.sha256(archive).hexdigest() != expected_digest:
+        raise RuntimeError(
+            "The downloaded uv archive failed checksum verification."
+            " Please try again."
+        )
+
+    uv_path.parent.mkdir(parents=True, exist_ok=True)
+    _extract_uv_binary(archive, asset_name, uv_path)
+    return str(uv_path)
+
+
+def create_managed_venv(venv_path: str) -> None:
+    """
+    Creates a venv with pip seeded into it, backed by a python interpreter of
+    the same minor version as the one anki is running on. Interpreters and uv
+    binaries already installed on the system are reused; downloading only
+    happens when neither is available.
+    """
+    native_python = _find_native_python()
+    if native_python is not None:
+        try:
+            subprocess.run(
+                [native_python, "-m", "venv", venv_path],
+                check=True,
+                text=True,
+                capture_output=True,
+            )
+            return
+        except subprocess.CalledProcessError:
+            # e.g. debian pythons without the python3-venv package; discard
+            # the half-created venv and fall back to uv
+            shutil.rmtree(venv_path, ignore_errors=True)
+
+    env = os.environ.copy()
+    uv_path = _find_native_uv()
+    if uv_path is None:
+        uv_path = ensure_uv()
+        # keep the downloaded interpreter and cache inside the bootstrap dir
+        # instead of ~/.local/share/uv etc. (a native uv keeps its own dirs,
+        # so pythons it has already installed get reused)
+        env["UV_PYTHON_INSTALL_DIR"] = str(_bootstrap_dir() / "python")
+        env["UV_CACHE_DIR"] = str(_bootstrap_dir() / "cache")
+
+    subprocess.run(
+        [
+            uv_path,
+            "venv",
+            "--seed",
+            "--managed-python",
+            "--no-config",
+            "--python",
+            f"{sys.version_info.major}.{sys.version_info.minor}",
+            venv_path,
+        ],
+        check=True,
+        text=True,
+        capture_output=True,
+        env=env,
+    )

--- a/ankimorphs/morphemizers/uv_bootstrap.py
+++ b/ankimorphs/morphemizers/uv_bootstrap.py
@@ -206,7 +206,10 @@ def _download(url: str) -> bytes:
     try:
         client = HttpClient()
         response = client.get(url)
-        return client.stream_content(response)
+        # the annotation matters: mypy runs without anki installed in ci,
+        # where stream_content would otherwise resolve to Any
+        archive: bytes = client.stream_content(response)
+        return archive
     except Exception as error:  # pylint:disable=broad-exception-caught
         raise RuntimeError(
             f"Downloading {url} failed. Check your internet connection and try again."

--- a/docs/src/user_guide/installation/installing-camel-tools.md
+++ b/docs/src/user_guide/installation/installing-camel-tools.md
@@ -11,7 +11,7 @@ From the Anki `Tools` menu, navigate to `AnkiMorphs` → `CAMeL Tools Manager`.
 ## Step 1: Install CAMeL Tools
 
 > **System requirements** (per the [CAMeL Tools installation docs](https://github.com/CAMeL-Lab/camel_tools#installation)):
-> - Python 3.11–3.14, 64-bit (Anki's bundled Python must meet this requirement)
+> - Python 3.11–3.14, 64-bit (satisfied automatically: Anki 26.x installs use a downloaded CPython matching Anki's version)
 > - The [Rust compiler](https://rustup.rs) must be installed before clicking Install
 > - `cmake` and `boost` must be installed before clicking Install
 >   - macOS: `brew install cmake boost`
@@ -21,6 +21,13 @@ From the Anki `Tools` menu, navigate to `AnkiMorphs` → `CAMeL Tools Manager`.
 
 Click **Install CAMeL Tools**. This downloads and installs CAMeL Tools into a dedicated virtual environment
 inside your Anki add-ons folder. After installation completes, **restart Anki**.
+
+> **Note**: on Anki 26.04 and later (self-contained builds), AnkiMorphs needs a Python interpreter
+> to create this environment. If your system already has a Python matching Anki's version, or `uv`,
+> it is reused and nothing extra is downloaded. Otherwise AnkiMorphs downloads `uv` and a standalone
+> Python (~60 MB total) into `addons21/ankimorphs-python-bootstrap` automatically. That folder is
+> shared by spaCy and CAMeL Tools, is not removed by "Purge", and can be deleted manually after
+> purging both.
 
 ## Step 2: Install a Database
 

--- a/docs/src/user_guide/installation/installing-spacy.md
+++ b/docs/src/user_guide/installation/installing-spacy.md
@@ -18,6 +18,13 @@ which will take you to the `spaCy manager` window:
   - macOS: `~/Library/Application Support/Anki2/addons21/spacy-venv-python-<version>`
   - Linux: `~/.local/share/Anki2/addons21/spacy-venv-python-<version>`
 
+  > **Note**: on Anki 26.04 and later (self-contained builds), AnkiMorphs needs a Python interpreter
+  > to create this folder. If your system already has a Python matching Anki's version, or `uv`, it
+  > is reused and nothing extra is downloaded. Otherwise AnkiMorphs downloads `uv` and a standalone
+  > Python (~60 MB total) into `addons21/ankimorphs-python-bootstrap` automatically. That folder is
+  > shared by spaCy and CAMeL Tools, is not removed by "Purge", and can be deleted manually after
+  > purging both.
+
   After the installation is complete you have to restart Anki before you can install any models.
 
 * **Install Model**:  

--- a/test/tests/uv_bootstrap_test.py
+++ b/test/tests/uv_bootstrap_test.py
@@ -77,7 +77,7 @@ def test_checksum_mismatch_aborts(
         uv_bootstrap.ensure_uv()
 
     # nothing may be written when verification fails
-    assert list(tmp_path.rglob("*")) == []
+    assert not list(tmp_path.rglob("*"))
 
 
 def test_extracts_uv_from_tarball(
@@ -105,9 +105,7 @@ def test_extracts_uv_from_tarball(
         assert os.access(uv_path, os.X_OK)
 
 
-def test_extracts_uv_from_zip(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_extracts_uv_from_zip(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     binary = b"fake uv binary"
     archive = _zip_with_uv(binary)
 
@@ -171,7 +169,7 @@ def test_create_managed_venv_prefers_native_python(
     captured: dict[str, Any] = {}
 
     def _fake_run(
-        command: list[str], **kwargs: Any
+        command: list[str], **_kwargs: Any
     ) -> subprocess.CompletedProcess[str]:
         captured["command"] = command
         return subprocess.CompletedProcess(command, 0)
@@ -198,7 +196,7 @@ def test_create_managed_venv_falls_back_to_uv_when_native_venv_fails(
     commands: list[list[str]] = []
 
     def _fake_run(
-        command: list[str], **kwargs: Any
+        command: list[str], **_kwargs: Any
     ) -> subprocess.CompletedProcess[str]:
         commands.append(command)
         if command[0] == "/usr/bin/python3.13":
@@ -284,7 +282,7 @@ def test_find_native_uv_version_gate(
     monkeypatch: pytest.MonkeyPatch, version_output: str, expected_path: str | None
 ) -> None:
     def _fake_run(
-        command: list[str], **kwargs: Any
+        command: list[str], **_kwargs: Any
     ) -> subprocess.CompletedProcess[str]:
         assert command == ["/native/uv", "--version"]
         return subprocess.CompletedProcess(command, 0, stdout=version_output)
@@ -326,7 +324,7 @@ def test_find_native_python_verifies_version_and_arch(
     )
 
     def _fake_run(
-        command: list[str], **kwargs: Any
+        command: list[str], **_kwargs: Any
     ) -> subprocess.CompletedProcess[str]:
         return subprocess.CompletedProcess(command, 0, stdout=probe_output)
 

--- a/test/tests/uv_bootstrap_test.py
+++ b/test/tests/uv_bootstrap_test.py
@@ -1,0 +1,346 @@
+from __future__ import annotations
+
+import hashlib
+import io
+import os
+import platform
+import subprocess
+import sys
+import tarfile
+import zipfile
+from pathlib import Path
+from typing import Any
+
+import pytest
+from anki.utils import is_win
+
+from ankimorphs.morphemizers import uv_bootstrap
+
+
+def _tarball_with_uv(binary: bytes) -> bytes:
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz") as tar_file:
+        member = tarfile.TarInfo(name="uv-x86_64-unknown-linux-gnu/uv")
+        member.size = len(binary)
+        tar_file.addfile(member, io.BytesIO(binary))
+    return buffer.getvalue()
+
+
+def _zip_with_uv(binary: bytes) -> bytes:
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, mode="w") as zip_file:
+        zip_file.writestr("uv.exe", binary)
+    return buffer.getvalue()
+
+
+@pytest.mark.parametrize(
+    "platform_name, machine, expected_asset",
+    [
+        ("darwin", "arm64", "uv-aarch64-apple-darwin.tar.gz"),
+        ("darwin", "x86_64", "uv-x86_64-apple-darwin.tar.gz"),
+        # windows reports AMD64/ARM64, which ensure_uv() lowercases before
+        # the lookup, so the map keys must be lowercase
+        ("win32", "amd64", "uv-x86_64-pc-windows-msvc.zip"),
+        ("win32", "arm64", "uv-aarch64-pc-windows-msvc.zip"),
+        ("linux", "x86_64", "uv-x86_64-unknown-linux-gnu.tar.gz"),
+        ("linux", "aarch64", "uv-aarch64-unknown-linux-gnu.tar.gz"),
+    ],
+)
+def test_uv_asset_selection(
+    platform_name: str, machine: str, expected_asset: str
+) -> None:
+    asset_name, digest = uv_bootstrap._uv_asset(platform_name, machine)
+    assert asset_name == expected_asset
+    assert len(digest) == 64
+
+
+def test_unsupported_platform_raises() -> None:
+    with pytest.raises(RuntimeError, match="does not have a Python download"):
+        uv_bootstrap._uv_asset("linux", "riscv64")
+
+
+def test_checksum_mismatch_aborts(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(uv_bootstrap, "_bootstrap_dir", lambda: tmp_path)
+    monkeypatch.setattr(
+        uv_bootstrap,
+        "_uv_asset",
+        lambda platform_name, machine: (
+            "uv-x86_64-unknown-linux-gnu.tar.gz",
+            hashlib.sha256(b"expected content").hexdigest(),
+        ),
+    )
+    monkeypatch.setattr(uv_bootstrap, "_download", lambda url: b"evil")
+
+    with pytest.raises(RuntimeError, match="checksum"):
+        uv_bootstrap.ensure_uv()
+
+    # nothing may be written when verification fails
+    assert list(tmp_path.rglob("*")) == []
+
+
+def test_extracts_uv_from_tarball(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    binary = b"fake uv binary"
+    archive = _tarball_with_uv(binary)
+
+    monkeypatch.setattr(uv_bootstrap, "_bootstrap_dir", lambda: tmp_path)
+    monkeypatch.setattr(
+        uv_bootstrap,
+        "_uv_asset",
+        lambda platform_name, machine: (
+            "uv-x86_64-unknown-linux-gnu.tar.gz",
+            hashlib.sha256(archive).hexdigest(),
+        ),
+    )
+    monkeypatch.setattr(uv_bootstrap, "_download", lambda url: archive)
+
+    uv_path = Path(uv_bootstrap.ensure_uv())
+
+    assert uv_path.parent == tmp_path / "uv"
+    assert uv_path.read_bytes() == binary
+    if not is_win:
+        assert os.access(uv_path, os.X_OK)
+
+
+def test_extracts_uv_from_zip(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    binary = b"fake uv binary"
+    archive = _zip_with_uv(binary)
+
+    monkeypatch.setattr(uv_bootstrap, "_bootstrap_dir", lambda: tmp_path)
+    monkeypatch.setattr(
+        uv_bootstrap,
+        "_uv_asset",
+        lambda platform_name, machine: (
+            "uv-x86_64-pc-windows-msvc.zip",
+            hashlib.sha256(archive).hexdigest(),
+        ),
+    )
+    monkeypatch.setattr(uv_bootstrap, "_download", lambda url: archive)
+
+    uv_path = Path(uv_bootstrap.ensure_uv())
+
+    assert uv_path.parent == tmp_path / "uv"
+    assert uv_path.read_bytes() == binary
+    if not is_win:
+        assert os.access(uv_path, os.X_OK)
+
+
+def test_create_managed_venv_downloads_uv_when_nothing_is_native(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def _fake_run(
+        command: list[str], **kwargs: Any
+    ) -> subprocess.CompletedProcess[str]:
+        captured["command"] = command
+        captured["env"] = kwargs["env"]
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(uv_bootstrap, "_bootstrap_dir", lambda: tmp_path)
+    monkeypatch.setattr(uv_bootstrap, "_find_native_python", lambda: None)
+    monkeypatch.setattr(uv_bootstrap, "_find_native_uv", lambda: None)
+    monkeypatch.setattr(uv_bootstrap, "ensure_uv", lambda: "/fake/uv")
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+
+    venv_path = str(tmp_path / "spacy-venv-python-3_13")
+    uv_bootstrap.create_managed_venv(venv_path)
+
+    assert captured["command"] == [
+        "/fake/uv",
+        "venv",
+        "--seed",
+        "--managed-python",
+        "--no-config",
+        "--python",
+        f"{sys.version_info.major}.{sys.version_info.minor}",
+        venv_path,
+    ]
+    assert captured["env"]["UV_PYTHON_INSTALL_DIR"] == str(tmp_path / "python")
+    assert captured["env"]["UV_CACHE_DIR"] == str(tmp_path / "cache")
+
+
+def test_create_managed_venv_prefers_native_python(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def _fake_run(
+        command: list[str], **kwargs: Any
+    ) -> subprocess.CompletedProcess[str]:
+        captured["command"] = command
+        return subprocess.CompletedProcess(command, 0)
+
+    def _no_download() -> str:
+        raise AssertionError("must not download uv when a native python exists")
+
+    monkeypatch.setattr(uv_bootstrap, "_bootstrap_dir", lambda: tmp_path)
+    monkeypatch.setattr(
+        uv_bootstrap, "_find_native_python", lambda: "/usr/bin/python3.13"
+    )
+    monkeypatch.setattr(uv_bootstrap, "ensure_uv", _no_download)
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+
+    venv_path = str(tmp_path / "spacy-venv-python-3_13")
+    uv_bootstrap.create_managed_venv(venv_path)
+
+    assert captured["command"] == ["/usr/bin/python3.13", "-m", "venv", venv_path]
+
+
+def test_create_managed_venv_falls_back_to_uv_when_native_venv_fails(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    commands: list[list[str]] = []
+
+    def _fake_run(
+        command: list[str], **kwargs: Any
+    ) -> subprocess.CompletedProcess[str]:
+        commands.append(command)
+        if command[0] == "/usr/bin/python3.13":
+            # e.g. debian without the python3-venv package
+            raise subprocess.CalledProcessError(1, command, stderr="no ensurepip")
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(uv_bootstrap, "_bootstrap_dir", lambda: tmp_path)
+    monkeypatch.setattr(
+        uv_bootstrap, "_find_native_python", lambda: "/usr/bin/python3.13"
+    )
+    monkeypatch.setattr(uv_bootstrap, "_find_native_uv", lambda: None)
+    monkeypatch.setattr(uv_bootstrap, "ensure_uv", lambda: "/fake/uv")
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+
+    venv_path = str(tmp_path / "spacy-venv-python-3_13")
+    (tmp_path / "spacy-venv-python-3_13").mkdir()  # half-created venv
+    uv_bootstrap.create_managed_venv(venv_path)
+
+    assert commands[0] == ["/usr/bin/python3.13", "-m", "venv", venv_path]
+    assert commands[1][:2] == ["/fake/uv", "venv"]
+    # the half-created venv must have been discarded before the uv attempt
+    assert not (tmp_path / "spacy-venv-python-3_13").exists()
+
+
+def test_create_managed_venv_uses_native_uv_with_its_own_dirs(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def _fake_run(
+        command: list[str], **kwargs: Any
+    ) -> subprocess.CompletedProcess[str]:
+        captured["command"] = command
+        captured["env"] = kwargs["env"]
+        return subprocess.CompletedProcess(command, 0)
+
+    def _no_download() -> str:
+        raise AssertionError("must not download uv when a native uv exists")
+
+    monkeypatch.delenv("UV_PYTHON_INSTALL_DIR", raising=False)
+    monkeypatch.delenv("UV_CACHE_DIR", raising=False)
+    monkeypatch.setattr(uv_bootstrap, "_bootstrap_dir", lambda: tmp_path)
+    monkeypatch.setattr(uv_bootstrap, "_find_native_python", lambda: None)
+    monkeypatch.setattr(uv_bootstrap, "_find_native_uv", lambda: "/native/uv")
+    monkeypatch.setattr(uv_bootstrap, "ensure_uv", _no_download)
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+
+    venv_path = str(tmp_path / "spacy-venv-python-3_13")
+    uv_bootstrap.create_managed_venv(venv_path)
+
+    assert captured["command"][0] == "/native/uv"
+    # a native uv keeps its default install/cache dirs so that pythons it
+    # has already installed get reused instead of re-downloaded
+    assert "UV_PYTHON_INSTALL_DIR" not in captured["env"]
+    assert "UV_CACHE_DIR" not in captured["env"]
+
+
+@pytest.mark.parametrize(
+    "version_output, expected",
+    [
+        ("uv 0.12.7 (0a1b2c3d4 2026-08-01)", (0, 12, 7)),
+        ("uv 0.6.8", (0, 6, 8)),
+        ("garbage", None),
+        ("", None),
+    ],
+)
+def test_uv_version_parsing(
+    version_output: str, expected: tuple[int, int, int] | None
+) -> None:
+    assert uv_bootstrap._uv_version(version_output) == expected
+
+
+@pytest.mark.parametrize(
+    "version_output, expected_path",
+    [
+        ("uv 0.12.7 (0a1b2c3d4 2026-08-01)", "/native/uv"),
+        ("uv 0.6.7", None),  # predates --managed-python
+        ("not a version", None),
+    ],
+)
+def test_find_native_uv_version_gate(
+    monkeypatch: pytest.MonkeyPatch, version_output: str, expected_path: str | None
+) -> None:
+    def _fake_run(
+        command: list[str], **kwargs: Any
+    ) -> subprocess.CompletedProcess[str]:
+        assert command == ["/native/uv", "--version"]
+        return subprocess.CompletedProcess(command, 0, stdout=version_output)
+
+    monkeypatch.setattr(uv_bootstrap, "_which", lambda command: "/native/uv")
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+
+    assert uv_bootstrap._find_native_uv() == expected_path
+
+
+def test_find_native_uv_without_uv_on_the_system(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(uv_bootstrap, "_which", lambda command: None)
+    assert uv_bootstrap._find_native_uv() is None
+
+
+@pytest.mark.parametrize(
+    "major_offset, minor_offset, machine, expected_match",
+    [
+        (0, 0, platform.machine(), True),
+        (0, 1, platform.machine(), False),  # wrong minor version
+        (1, 0, platform.machine(), False),  # wrong major version
+        (0, 0, "mismatched-arch", False),  # e.g. arm64 python for x86_64 anki
+    ],
+)
+def test_find_native_python_verifies_version_and_arch(
+    monkeypatch: pytest.MonkeyPatch,
+    major_offset: int,
+    minor_offset: int,
+    machine: str,
+    expected_match: bool,
+) -> None:
+    probe_output = (
+        f"{sys.version_info.major + major_offset}\n"
+        f"{sys.version_info.minor + minor_offset}\n"
+        f"{machine}\n"
+        "/usr/bin/python-resolved\n"
+    )
+
+    def _fake_run(
+        command: list[str], **kwargs: Any
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(command, 0, stdout=probe_output)
+
+    monkeypatch.setattr(
+        uv_bootstrap, "_which", lambda command: "/usr/bin/python-candidate"
+    )
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+
+    expected = "/usr/bin/python-resolved" if expected_match else None
+    assert uv_bootstrap._find_native_python() == expected
+
+
+def test_find_native_python_without_candidates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(uv_bootstrap, "_which", lambda command: None)
+    assert uv_bootstrap._find_native_python() is None

--- a/test/tests/uv_bootstrap_test.py
+++ b/test/tests/uv_bootstrap_test.py
@@ -9,6 +9,7 @@ import sys
 import tarfile
 import zipfile
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -156,7 +157,7 @@ def test_create_managed_venv_downloads_uv_when_nothing_is_native(
         "--managed-python",
         "--no-config",
         "--python",
-        f"{sys.version_info.major}.{sys.version_info.minor}",
+        uv_bootstrap._uv_python_request(),
         venv_path,
     ]
     assert captured["env"]["UV_PYTHON_INSTALL_DIR"] == str(tmp_path / "python")
@@ -300,28 +301,41 @@ def test_find_native_uv_without_uv_on_the_system(
     assert uv_bootstrap._find_native_uv() is None
 
 
+# what a regular CPython matching the running process prints when probed
+_MATCHING_PROBE = (
+    str(sys.version_info.major),
+    str(sys.version_info.minor),
+    platform.machine(),
+    "cpython",
+    "0",
+)
+
+
 @pytest.mark.parametrize(
-    "major_offset, minor_offset, machine, expected_match",
+    "probe_lines, expected_match",
     [
-        (0, 0, platform.machine(), True),
-        (0, 1, platform.machine(), False),  # wrong minor version
-        (1, 0, platform.machine(), False),  # wrong major version
-        (0, 0, "mismatched-arch", False),  # e.g. arm64 python for x86_64 anki
+        (_MATCHING_PROBE, True),
+        # wrong minor version
+        (
+            (_MATCHING_PROBE[0], str(sys.version_info.minor + 1)) + _MATCHING_PROBE[2:],
+            False,
+        ),
+        # wrong major version
+        ((str(sys.version_info.major + 1),) + _MATCHING_PROBE[1:], False),
+        # e.g. an arm64 python while anki runs as x86_64 under rosetta
+        (_MATCHING_PROBE[:2] + ("mismatched-arch",) + _MATCHING_PROBE[3:], False),
+        # pypy venvs would select incompatible wheels
+        (_MATCHING_PROBE[:3] + ("pypy", "0"), False),
+        # free-threaded builds use incompatible cp3XXt wheels
+        (_MATCHING_PROBE[:4] + ("1",), False),
     ],
 )
-def test_find_native_python_verifies_version_and_arch(
+def test_find_native_python_verifies_version_arch_and_implementation(
     monkeypatch: pytest.MonkeyPatch,
-    major_offset: int,
-    minor_offset: int,
-    machine: str,
+    probe_lines: tuple[str, ...],
     expected_match: bool,
 ) -> None:
-    probe_output = (
-        f"{sys.version_info.major + major_offset}\n"
-        f"{sys.version_info.minor + minor_offset}\n"
-        f"{machine}\n"
-        "/usr/bin/python-resolved\n"
-    )
+    probe_output = "\n".join([*probe_lines, "/usr/bin/python-resolved"]) + "\n"
 
     def _fake_run(
         command: list[str], **_kwargs: Any
@@ -342,3 +356,55 @@ def test_find_native_python_without_candidates(
 ) -> None:
     monkeypatch.setattr(uv_bootstrap, "_which", lambda command: None)
     assert uv_bootstrap._find_native_python() is None
+
+
+@pytest.mark.parametrize(
+    "platform_name, machine, expected_request",
+    [
+        ("darwin", "arm64", "cpython-3.13-macos-aarch64-none"),
+        ("darwin", "x86_64", "cpython-3.13-macos-x86_64-none"),
+        ("win32", "AMD64", "cpython-3.13-windows-x86_64-none"),
+        ("win32", "ARM64", "cpython-3.13-windows-aarch64-none"),
+        ("linux", "x86_64", "cpython-3.13-linux-x86_64-gnu"),
+        ("linux", "aarch64", "cpython-3.13-linux-aarch64-gnu"),
+    ],
+)
+def test_uv_python_request_is_arch_qualified(
+    monkeypatch: pytest.MonkeyPatch,
+    platform_name: str,
+    machine: str,
+    expected_request: str,
+) -> None:
+    monkeypatch.setattr(sys, "platform", platform_name)
+    monkeypatch.setattr(sys, "version_info", SimpleNamespace(major=3, minor=13))
+    monkeypatch.setattr(platform, "machine", lambda: machine)
+
+    assert uv_bootstrap._uv_python_request() == expected_request
+
+
+def test_archive_without_uv_member_raises(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz") as tar_file:
+        member = tarfile.TarInfo(name="uv-x86_64-unknown-linux-gnu/README.md")
+        member.size = 0
+        tar_file.addfile(member, io.BytesIO(b""))
+    archive = buffer.getvalue()
+
+    monkeypatch.setattr(uv_bootstrap, "_bootstrap_dir", lambda: tmp_path)
+    monkeypatch.setattr(
+        uv_bootstrap,
+        "_uv_asset",
+        lambda platform_name, machine: (
+            "uv-x86_64-unknown-linux-gnu.tar.gz",
+            hashlib.sha256(archive).hexdigest(),
+        ),
+    )
+    monkeypatch.setattr(uv_bootstrap, "_download", lambda url: archive)
+
+    with pytest.raises(RuntimeError, match="did not contain a uv binary"):
+        uv_bootstrap.ensure_uv()
+
+    # no binary and no leftover temp file may exist anywhere
+    assert not [path for path in tmp_path.rglob("*") if path.is_file()]


### PR DESCRIPTION
Closes #426

**Problem**

The official Anki 26.x builds are self-contained apps: 26.08 removed `aqt.package.venv_binary` and `sys.executable` is the frozen `anki` binary, so `get_python_binary()` returns `None` and installing spaCy or CAMeL Tools dead-ends with "requires Anki 25.09.x" (still the case on 26.09b1; ankitects/anki#5033 is unresolved).

**Solution**

When `get_python_binary()` returns `None`, the new `uv_bootstrap` module provisions an interpreter, trying the cheapest option first:

1. **A CPython already on the system** matching Anki's `major.minor` and architecture (probed via `python3.X` on PATH + well-known locations, and the `py` launcher on Windows) — used directly with `python -m venv`, nothing downloaded. If venv creation fails (e.g. Debian without `python3-venv`), it falls through to uv.
2. **A uv already on the system** (version-gated to ≥ 0.6.8, the release that added `--managed-python`) — runs `uv venv --seed --managed-python --no-config` with an architecture-qualified request (e.g. `cpython-3.13-macos-x86_64-none`), reusing any CPython that uv has already installed, so this usually downloads nothing either.
3. **Download uv 0.12.7** (pinned, sha256-verified against the official astral-sh release) into `addons21/ankimorphs-python-bootstrap/` and let it install a standalone CPython there. Nothing is bundled in the addon zip; no PATH shims or registry entries are created; the long-term maintenance surface is bumping one version pin.

The native reuse is defensive: the python probe requires a regular CPython (rejects PyPy and free-threaded builds, whose venvs would select wheels Anki's embedded CPython cannot import) matching Anki's version and architecture, and the arch-qualified uv request means a native uv of a different architecture — say arm64 uv with an Intel Anki under Rosetta — still provisions a compatible python.

Everything downstream (pip upgrade, `pip install spacy`, model downloads, `camel_data`) already runs through the venv's own python and is untouched. Anki ≤ 25.09 and python-based installs (distro/flatpak) keep the current `python -m venv` path exactly as-is.

**Platforms covered**

All six official Anki 26.x targets: Windows x64/arm64, macOS Apple/Intel, Linux x86_64/aarch64. musl and other unlisted platforms get a clear "no Python download for this platform" error (official builds are glibc-only, and python-based installs never reach this code).

**Verified**

Manually, end-to-end on Anki 26.09b1 (macOS arm64, embedded CPython 3.13):

- *Download path* (no native tools visible): clicking Install spaCy downloaded uv + a standalone CPython 3.13.15 into `addons21/ankimorphs-python-bootstrap/`, created `spacy-venv-python-3_13`, and installed spaCy 3.8.16 into it.
- *Native reuse path* (host has uv 0.12.x): same click created the venv against the host uv's existing CPython 3.13.5 with **no** bootstrap folder and no downloads; success dialog shown; after restart the spaCy Manager reports "spaCy is installed for python 3.13" (i.e. the addon imports spaCy in-process from the venv), `en_core_web_sm` installed, and `spacy.util.get_installed_models()` — the exact call that populates the morphemizer dropdown — returns `['en_core_web_sm']`. CAMeL venv creation was exercised through the same code path (the CAMeL pip build itself still needs the documented rust/cmake/boost prerequisites, unchanged).

By CI: 16 new unit-test functions, 36 parametrized cases (asset map for all six targets, checksum-mismatch abort, tar/zip extraction incl. a no-member archive, native-python probing with version/arch/implementation/free-threading rejection, the uv version gate, the arch-qualified python request for all six targets, and all three `create_managed_venv` branches) run natively on ubuntu/macos/windows via the existing workflow, alongside the full pre-commit gate (black, isort, pyupgrade, vulture, codespell, pylint, strict mypy). Windows/Linux Anki GUI runs were not performed — the code path is OS-identical and covered by the platform-parametrized tests. The download-failure dialog was not exercised live (would have required cutting network); it is unit-tested.

**Note**: on merge, the AnkiWeb listing paragraph recommending Anki 25.09 for spaCy/CAMeL installs becomes outdated and can be rewritten.
