### PR TITLE
Read the card-morph map without joining and sorting

### DIFF
--- a/ankimorphs/ankimorphs_db.py
+++ b/ankimorphs/ankimorphs_db.py
@@ -459,32 +459,41 @@ class AnkiMorphsDB:  # pylint:disable=too-many-public-methods
         card_morph_map_cache: dict[int, list[Morpheme]] = {}
 
         # the same morph is on many cards, and sharing one object per morph
-        interned_morphs: dict[tuple[str, str], Morpheme] = {}
+        interned_morphs: dict[tuple[str, str], Morpheme] = {
+            (row[0], row[1]): Morpheme(
+                lemma=row[0],
+                inflection=row[1],
+                highest_lemma_learning_interval=row[2],
+                highest_inflection_learning_interval=row[3],
+            )
+            for row in self.con.execute(
+                """
+                SELECT lemma, inflection, highest_lemma_learning_interval, highest_inflection_learning_interval
+                FROM Morphs
+                """,
+            ).fetchall()
+        }
 
         # Sorting the morphs (ORDER BY) is crucial to avoid bugs
+        #
+        # The map table is read on its own rather than joined with Morphs: its
+        # primary key already is (card_id, morph_lemma, morph_inflection), so
+        # this order comes straight from the index, and a row with no matching
+        # morph is skipped below just as the inner join dropped it.
         card_morph_map_cache_raw = self.con.execute(
             """
-            SELECT Card_Morph_Map.card_id, Morphs.lemma, Morphs.inflection, Morphs.highest_lemma_learning_interval, Morphs.highest_inflection_learning_interval
+            SELECT card_id, morph_lemma, morph_inflection
             FROM Card_Morph_Map
-            INNER JOIN Morphs ON
-                Card_Morph_Map.morph_lemma = Morphs.lemma AND Card_Morph_Map.morph_inflection = Morphs.inflection
-            ORDER BY Morphs.lemma, Morphs.inflection
+            ORDER BY card_id, morph_lemma, morph_inflection
             """,
         ).fetchall()
 
         for row in card_morph_map_cache_raw:
             card_id = row[0]
-            morph_key = (row[1], row[2])
-            morph = interned_morphs.get(morph_key)
+            morph = interned_morphs.get((row[1], row[2]))
 
             if morph is None:
-                morph = Morpheme(
-                    lemma=row[1],
-                    inflection=row[2],
-                    highest_lemma_learning_interval=row[3],
-                    highest_inflection_learning_interval=row[4],
-                )
-                interned_morphs[morph_key] = morph
+                continue
 
             if card_id not in card_morph_map_cache:
                 card_morph_map_cache[card_id] = [morph]


### PR DESCRIPTION
## What is the current behavior?

`AnkiMorphsDB.get_card_morph_map_cache()` builds the `{card_id: [Morpheme, ...]}` dictionary required for recalculation using a single query that joins `Card_Morph_Map` and `Morphs`, ordered by `lemma, inflection`:

```sql
SELECT Card_Morph_Map.card_id, Morphs.lemma, Morphs.inflection, ...
FROM Card_Morph_Map
INNER JOIN Morphs ON
    Card_Morph_Map.morph_lemma = Morphs.lemma AND Card_Morph_Map.morph_inflection = Morphs.inflection
ORDER BY Morphs.lemma, Morphs.inflection
```

On `big_japanese_collection`, `Card_Morph_Map` contains 235,279 rows. Joining and sorting all 235k rows is redundant: only 14,302 distinct morphemes exist, and the subsequent Python loop immediately deduplicates them into single `Morpheme` instances.

## What is the new behavior?

The operation is split into two simpler queries:

1. Query `Morphs` directly once to populate the unique `Morpheme` cache.
2. Query `Card_Morph_Map`:

```sql
SELECT card_id, morph_lemma, morph_inflection
FROM Card_Morph_Map
ORDER BY card_id, morph_lemma, morph_inflection
```

Because `(card_id, morph_lemma, morph_inflection)` is the table's primary key, SQLite performs an index scan instead of an explicit sort, avoiding per-row lookups into `Morphs`.

**Invariants:**
- **Ordering:** Within each card, morphemes remain sorted by `(lemma, inflection)`. Top-level iteration order between cards changes, but the return value is a dict keyed by `card_id`.
- **Filtering:** Rows without a corresponding entry in `Morphs` are skipped, preserving `INNER JOIN` semantics.

### Performance

Benchmarked on `big_japanese_collection` (36,850 cards), 15 runs. `mecab_wrapper`'s LRU cache was cleared prior to each run:

| Branch | Median | Min |
|---|---|---|
| `main` | 1,293.2 ms | 1,227.8 ms |
| this PR | **536.8 ms** (-58%) | 502.6 ms |

**Recalc impact:**
- Function runtime decreased by ~58% (~750 ms saved per recalc).
- End-to-end: -8.5% total time on quiet recalcs; -1.5% on note-heavy recalcs (30k notes).
- No regressions observed across tested scenarios.

## What kind of changes does this PR introduce?

- [x] Performance improvement (no change in behaviour, schema or public API)

## Checklist:

- [x] My code successfully passes pre-commit
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I am willing to help create documentation/guides for the changes made in this PR
- [x] This PR can be rebased onto main without conflicts (create a backup branch before attempting a rebase)
- [x] I have squashed my commits into sensible portions